### PR TITLE
ci: run lint and test on pull_request, not just push

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,6 +1,9 @@
 name: Lint and Test
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to enabling required status checks on `main`.

`lint_and_test.yml` used `on: [push]`, which has two consequences now that **`build (3.13)` is a required check**:

## 1. Fork PRs would be permanently unmergeable

The repo is public. A PR from a fork never fires a `push` event in this repo, so the required `build (3.13)` check would never report — and a required check that never reports cannot be satisfied. An outside contributor's PR would be stuck with no way to merge it.

## 2. Post-merge validation on main had silently stopped

The suite has not run on `main` since `56eb68a` on **13 Jul**, despite ~10 commits landing since. Dependabot auto-merges push using `GITHUB_TOKEN`, and GitHub deliberately does not re-trigger `on: push` workflows from token-driven pushes, to avoid recursion. So every dependabot merge since then went unvalidated on `main`.

This is also how PR #29 merged with `build (3.13)` failing.

## Change

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

- `pull_request` puts the gate before the merge, where it actually blocks, and makes it work for forks.
- Restricting `push` to `main` keeps post-merge runs without double-running on every branch push that already has a PR open.

Job name and matrix are unchanged, so the required context is still exactly `build (3.13)` — no branch-protection update needed.

## Verification

Ran the workflow's own gates locally against `main`:

```
uv run python -m pytest tests        # 175 passed, 2 subtests passed
uv run pylint --fail-under=9.9 src tests   # rated 10.00/10
```

This PR is its own test: `build (3.13)` reporting here comes from the new `pull_request` trigger.